### PR TITLE
feat: add activity splits and per-second detail queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v1.3.0 (2026-06-02)
+
+### 🏃 Activity Detail & Splits - Per-Second and Per-Lap Data
+
+**NEW: Query individual activity details with per-second time-series and per-lap splits!**
+
+- Added `activity_splits` subcommand to `garmin_data.py` — get per-lap HR, speed, distance, power, cadence, elevation for any activity
+- Added `activity_detail` subcommand to `garmin_data.py` — get per-second time-series data with all metrics (HR, speed, distance, elevation, power, cadence, GPS coordinates, and more)
+  - `--metrics` flag to select specific metrics (e.g., `directHeartRate,directSpeed,sumDistance`)
+  - `--sample-interval` flag to downsample output (e.g., `--sample-interval 30` for every 30 seconds)
+- Added `activity_id` field to `activities` output — makes it easy to query specific activity details
+- Updated SKILL.md with new command documentation and question examples
+- 20+ available per-second metrics including: heart rate, speed, distance, elevation, power, cadence, GPS, grade-adjusted speed, vertical oscillation, ground contact time, stride length, vertical ratio, performance condition
+
+**Usage examples:**
+```bash
+# Get lap splits for a run
+python3 scripts/garmin_data.py activity_splits --activity-id 600107330
+
+# Get per-second HR and speed (sampled every 30s)
+python3 scripts/garmin_data.py activity_detail --activity-id 600107330 \
+  --metrics directHeartRate,directSpeed,sumDistance --sample-interval 30
+
+# Get all metrics at full resolution
+python3 scripts/garmin_data.py activity_detail --activity-id 600107330
+```
+
 ## v1.2.2 (2026-01-26)
 
 ### 🧹 Repository Cleanup & Focus

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: garmin-health-analysis
 description: Talk to your Garmin data naturally - "what was my fastest speed snowboarding?", "how did I sleep last night?", "what was my heart rate at 3pm?". Access 20+ metrics (sleep stages, Body Battery, HRV, VO2 max, training readiness, body composition, SPO2), download FIT/GPX files for route analysis, query elevation/pace at any point, and generate interactive health dashboards. From casual "show me this week's workouts" to deep "analyze my recovery vs training load".
-version: 1.2.2
+version: 1.3.0
 author: EversonL & Claude
 homepage: https://github.com/eversonl/ClawdBot-garmin-health-analysis
 metadata: {"clawdbot":{"emoji":"⌚","requires":{"env":["GARMIN_EMAIL","GARMIN_PASSWORD"]},"install":[{"id":"garminconnect","kind":"python","package":"garminconnect","label":"Install garminconnect (pip)"},{"id":"fitparse","kind":"python","package":"fitparse","label":"Install fitparse (pip)"},{"id":"gpxpy","kind":"python","package":"gpxpy","label":"Install gpxpy (pip)"}]}}
@@ -124,7 +124,7 @@ python3 scripts/garmin_data.py hrv --days 30
 # Heart rate (resting, max, min)
 python3 scripts/garmin_data.py heart_rate --days 7
 
-# Activities/workouts
+# Activities/workouts (now includes activity_id)
 python3 scripts/garmin_data.py activities --days 30
 
 # Stress levels
@@ -138,6 +138,51 @@ python3 scripts/garmin_data.py sleep --start 2026-01-01 --end 2026-01-15
 
 # User profile
 python3 scripts/garmin_data.py profile
+```
+
+### Activity Splits (per-lap data)
+
+Get lap-by-lap data for a specific activity — average/max HR, speed, distance, power, cadence per lap:
+
+```bash
+# Get lap splits for an activity (use activities to find activity_id)
+python3 scripts/garmin_data.py activity_splits --activity-id 600107330
+```
+
+Returns per-lap: `lap_index`, `distance_meters`, `duration_seconds`, `average_speed`, `max_speed`, `avg_hr`, `max_hr`, `calories`, `elevation_gain`, `average_power`, `normalized_power`, `average_run_cadence`, `intensity_type`, etc.
+
+### Activity Detail (per-second time-series)
+
+Get second-by-second data for a specific activity — heart rate, speed, distance, elevation, power, cadence, and more:
+
+```bash
+# All metrics, every second (full resolution)
+python3 scripts/garmin_data.py activity_detail --activity-id 600107330
+
+# Specific metrics only (faster, smaller output)
+python3 scripts/garmin_data.py activity_detail --activity-id 600107330 \
+  --metrics directHeartRate,directSpeed,sumDistance
+
+# Sample every 30 seconds (good for quick overview of a long activity)
+python3 scripts/garmin_data.py activity_detail --activity-id 600107330 \
+  --sample-interval 30
+
+# Common metrics:
+#   directHeartRate   - Heart rate (bpm)
+#   directSpeed       - Speed (m/s)
+#   sumDistance        - Cumulative distance (m)
+#   directElevation   - Elevation (m)
+#   directPower       - Power (watts, running/cycling)
+#   directRunCadence  - Cadence (spm for running)
+#   directTimestamp   - Timestamp (ms epoch)
+#   directLatitude    - Latitude
+#   directLongitude   - Longitude
+#   directGradeAdjustedSpeed - Grade-adjusted speed (m/s)
+#   directVerticalOscillation - Vertical oscillation (cm)
+#   directGroundContactTime  - Ground contact time (ms)
+#   directStrideLength - Stride length (cm)
+#   directVerticalRatio - Vertical ratio (%)
+#   directPerformanceCondition - Performance condition
 ```
 
 Output is JSON to stdout. Parse it to answer user questions.
@@ -178,6 +223,9 @@ Charts open automatically in the default browser. They use Chart.js with a moder
 | "Is my HRV improving?" | `garmin_data.py hrv --days 30`, analyze trend |
 | "What workouts did I do this week?" | `garmin_data.py activities --days 7`, list activities with details |
 | "How's my resting heart rate?" | `garmin_data.py heart_rate --days 7`, report average + trend |
+| "Show me my heart rate during my run" | `garmin_data.py activity_detail --activity-id ID --metrics directHeartRate,directSpeed --sample-interval 30` |
+| "What were my lap splits?" | `garmin_data.py activity_splits --activity-id ID`, report per-lap HR + pace |
+| "How did my pace change over the run?" | `garmin_data.py activity_detail --activity-id ID --metrics directSpeed,sumDistance --sample-interval 60` |
 
 ## Key Metrics
 
@@ -276,6 +324,6 @@ When users ask for insights or want to understand their trends, use `references/
 
 - **Created**: 2026-01-25
 - **Author**: EversonL & Claude
-- **Version**: 1.2.0
+- **Version**: 1.3.0
 - **Dependencies**: garminconnect, fitparse, gpxpy (Python libraries)
 - **License**: MIT

--- a/scripts/garmin_data.py
+++ b/scripts/garmin_data.py
@@ -194,6 +194,7 @@ def fetch_activities(client, days=7, start=None, end=None):
         activity_list = []
         for activity in activities:
             activity_list.append({
+                "activity_id": activity.get("activityId"),
                 "date": activity.get("startTimeLocal", "").split(" ")[0],
                 "activity_type": activity.get("activityType", {}).get("typeKey"),
                 "activity_name": activity.get("activityName"),
@@ -210,6 +211,101 @@ def fetch_activities(client, days=7, start=None, end=None):
     
     except Exception as e:
         return {"error": str(e)}
+
+
+def fetch_activity_splits(client, activity_id):
+    """Fetch lap/split data for a specific activity (per-lap HR, speed, distance, etc.)."""
+    try:
+        splits = client.get_activity_splits(activity_id)
+        lap_dtos = splits.get("lapDTOs", [])
+        
+        lap_list = []
+        for lap in lap_dtos:
+            lap_list.append({
+                "lap_index": lap.get("lapIndex"),
+                "start_time_gmt": lap.get("startTimeGMT"),
+                "distance_meters": lap.get("distance"),
+                "duration_seconds": lap.get("duration"),
+                "moving_duration": lap.get("movingDuration"),
+                "average_speed": lap.get("averageSpeed"),
+                "average_moving_speed": lap.get("averageMovingSpeed"),
+                "max_speed": lap.get("maxSpeed"),
+                "avg_hr": lap.get("averageHR"),
+                "max_hr": lap.get("maxHR"),
+                "calories": lap.get("calories"),
+                "elevation_gain": lap.get("elevationGain"),
+                "elevation_loss": lap.get("elevationLoss"),
+                "max_elevation": lap.get("maxElevation"),
+                "min_elevation": lap.get("minElevation"),
+                "average_run_cadence": lap.get("averageRunCadence"),
+                "max_run_cadence": lap.get("maxRunCadence"),
+                "average_power": lap.get("averagePower"),
+                "max_power": lap.get("maxPower"),
+                "normalized_power": lap.get("normalizedPower"),
+                "intensity_type": lap.get("intensityType"),
+            })
+        
+        return {"activity_id": activity_id, "laps": lap_list, "lap_count": len(lap_list)}
+    
+    except Exception as e:
+        return {"error": str(e), "activity_id": activity_id}
+
+
+def fetch_activity_detail(client, activity_id, metrics=None, sample_interval=1):
+    """Fetch per-second time-series data for a specific activity.
+    
+    Args:
+        client: Garmin client instance
+        activity_id: Activity ID
+        metrics: Comma-separated list of metric keys to include (default: all).
+                 Common keys: directHeartRate, directSpeed, sumDistance, directElevation,
+                 directPower, directRunCadence, directTimestamp
+        sample_interval: Output every N-th data point (default: 1 = every second).
+                         Use 10 for every 10 seconds, 30 for every 30 seconds, etc.
+    """
+    try:
+        details = client.get_activity_details(activity_id)
+        
+        # Build metric key -> index mapping
+        metric_descriptors = details.get("metricDescriptors", [])
+        key_to_idx = {}
+        for i, md in enumerate(metric_descriptors):
+            key_to_idx[md.get("key")] = i
+        
+        detail_data = details.get("activityDetailMetrics", [])
+        
+        # Determine which metrics to extract
+        if metrics:
+            requested_keys = [k.strip() for k in metrics.split(",")]
+        else:
+            requested_keys = list(key_to_idx.keys())
+        
+        # Build index mapping for requested keys only
+        selected = [(k, key_to_idx[k]) for k in requested_keys if k in key_to_idx]
+        
+        # Extract time-series data
+        time_series = []
+        for i, dp in enumerate(detail_data):
+            if i % sample_interval != 0:
+                continue
+            m = dp.get("metrics", [])
+            point = {}
+            for key, idx in selected:
+                point[key] = m[idx] if idx < len(m) else None
+            time_series.append(point)
+        
+        return {
+            "activity_id": activity_id,
+            "total_data_points": len(detail_data),
+            "sample_interval": sample_interval,
+            "sampled_points": len(time_series),
+            "available_metrics": list(key_to_idx.keys()),
+            "selected_metrics": [k for k, _ in selected],
+            "time_series": time_series
+        }
+    
+    except Exception as e:
+        return {"error": str(e), "activity_id": activity_id}
 
 
 def fetch_stress(client, days=7, start=None, end=None):
@@ -318,11 +414,18 @@ def fetch_profile(client):
 
 def main():
     parser = argparse.ArgumentParser(description="Fetch Garmin health data")
-    parser.add_argument("metric", choices=["sleep", "hrv", "body_battery", "heart_rate", "activities", "stress", "summary", "profile"],
-                       help="Type of data to fetch")
+    parser.add_argument("metric", choices=[
+        "sleep", "hrv", "body_battery", "heart_rate", "activities",
+        "stress", "summary", "profile", "activity_splits", "activity_detail"
+    ], help="Type of data to fetch")
     parser.add_argument("--days", type=int, default=7, help="Number of days to fetch (default: 7)")
     parser.add_argument("--start", help="Start date (YYYY-MM-DD)")
     parser.add_argument("--end", help="End date (YYYY-MM-DD)")
+    parser.add_argument("--activity-id", type=int, help="Activity ID (required for activity_splits/activity_detail)")
+    parser.add_argument("--metrics", help="Comma-separated metric keys for activity_detail (default: all). "
+                       "Common: directHeartRate,directSpeed,sumDistance,directElevation,directPower,directRunCadence")
+    parser.add_argument("--sample-interval", type=int, default=1,
+                       help="Sample every N-th data point for activity_detail (default: 1 = every second)")
     
     args = parser.parse_args()
     
@@ -349,6 +452,16 @@ def main():
         result = fetch_summary(client, args.days, args.start, args.end)
     elif args.metric == "profile":
         result = fetch_profile(client)
+    elif args.metric == "activity_splits":
+        if not args.activity_id:
+            print('{"error": "--activity-id is required for activity_splits. Use activities to find IDs."}')
+            sys.exit(1)
+        result = fetch_activity_splits(client, args.activity_id)
+    elif args.metric == "activity_detail":
+        if not args.activity_id:
+            print('{"error": "--activity-id is required for activity_detail. Use activities to find IDs."}')
+            sys.exit(1)
+        result = fetch_activity_detail(client, args.activity_id, args.metrics, args.sample_interval)
     
     # Output JSON
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary

The skill currently only returns activity summaries (type, duration, calories, etc.) but cannot drill into per-lap or per-second data. This PR adds two new subcommands to `garmin_data.py` that expose `get_activity_splits` and `get_activity_details` from the `garminconnect` API.

## Changes

- **`scripts/garmin_data.py`**
  - New `fetch_activity_splits(client, activity_id)` — per-lap data: HR, speed, distance, power, cadence, elevation
  - New `fetch_activity_detail(client, activity_id, metrics, sample_interval)` — per-second time-series with metric filtering and downsampling
  - `activity_id` field added to `fetch_activities()` output for easy follow-up queries
  - New CLI args: `--activity-id`, `--metrics`, `--sample-interval`
  - New subcommands: `activity_splits`, `activity_detail`

- **`SKILL.md`** — Updated with new command docs, usage examples, and question examples (version → 1.3.0)

- **`CHANGELOG.md`** — Added v1.3.0 entry

## Usage Examples

```bash
# Get lap splits for a run
python3 scripts/garmin_data.py activity_splits --activity-id 600107330

# Get per-second HR and speed (sampled every 30s)
python3 scripts/garmin_data.py activity_detail --activity-id 600107330 \
  --metrics directHeartRate,directSpeed,sumDistance --sample-interval 30

# Get all metrics at full resolution
python3 scripts/garmin_data.py activity_detail --activity-id 600107330
```

## 20+ Available Per-Second Metrics

`directHeartRate`, `directSpeed`, `sumDistance`, `directElevation`, `directPower`, `directRunCadence`, `directBikeCadence`, `sumHeartRate`, `sumSpeed`, `directTimestamp`, `directAirTemperature`, `directGpsSpeed`, `directGradeAdjustedSpeed`, `directVerticalOscillation`, `directGroundContactTime`, `directStrideLength`, `directVerticalRatio`, `directPerformanceCondition`, and more.

## Testing

Tested with real Garmin Connect data:
- `activity_splits` on a 4.17km run (activity_id 600107330) — returned 5 laps with per-lap metrics
- `activity_detail` on the same run — returned per-second HR/speed/distance with `--sample-interval 30` downsampling
- `activity_detail` on a 6.47km ride (activity_id 600905744) — confirmed cycling-specific metrics (power, bike cadence)

AI assistance was used in developing this PR.