### PR TITLE
Improve auth resilience: 429 retry, token fallback, legacy migration, credential resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd ~/.clawdbot/skills
 git clone https://github.com/eversonl/ClawdBot-garmin-health-analysis.git garmin-health-analysis
 
 # Install dependencies
-pip3 install garminconnect fitparse gpxpy
+pip3 install garminconnect curl_cffi fitparse gpxpy
 
 # Configure credentials and authenticate
 python3 scripts/garmin_auth.py login

--- a/SKILL.md
+++ b/SKILL.md
@@ -100,7 +100,9 @@ This uses credentials from (in priority order):
 3. Environment variables (`GARMIN_EMAIL`, `GARMIN_PASSWORD`)
 4. Clawdbot config (`skills.entries.garmin-health-analysis.env`)
 
-Session tokens are stored in `~/.clawdbot/garmin-tokens.json` and auto-refresh.
+Session tokens are stored in `~/.clawdbot/garmin/` (garth tokenstore) and auto-refresh on subsequent calls.
+
+If you have existing tokens from a previous version (`~/.garminconnect/`), they are automatically migrated on first use.
 
 Check authentication status:
 ```bash
@@ -248,10 +250,12 @@ When users ask for insights or want to understand their trends, use `references/
 
 ## Privacy Note
 
-- Credentials are stored locally in `~/.clawdbot/garmin-tokens.json`
-- Session tokens refresh automatically
+- Credentials are stored locally in `~/.clawdbot/garmin/` (garth tokenstore directory)
+- Session tokens auto-refresh; if they expire, the module falls back to credentials from config/env
+- Legacy tokens from `~/.garminconnect/` are automatically migrated on first use
+- Rate-limited? The auth module retries once after 30s and tells you what to do
 - No data is sent anywhere except to Garmin's official servers
-- You can revoke access anytime by deleting the tokens file
+- You can revoke access anytime by deleting the `~/.clawdbot/garmin/` directory
 
 ## Comparison: Garmin vs Whoop
 
@@ -276,6 +280,6 @@ When users ask for insights or want to understand their trends, use `references/
 
 - **Created**: 2026-01-25
 - **Author**: EversonL & Claude
-- **Version**: 1.2.0
+- **Version**: 1.2.2
 - **Dependencies**: garminconnect, fitparse, gpxpy (Python libraries)
 - **License**: MIT

--- a/install.sh
+++ b/install.sh
@@ -19,15 +19,15 @@ echo "✓ Python 3 found: $(python3 --version)"
 echo
 echo "📦 Installing Python dependencies..."
 
-if pip3 install --user garminconnect fitparse gpxpy 2>/dev/null; then
+if pip3 install --user garminconnect curl_cffi fitparse gpxpy 2>/dev/null; then
     echo "✓ Dependencies installed (--user)"
-elif pip3 install --break-system-packages garminconnect fitparse gpxpy 2>/dev/null; then
+elif pip3 install --break-system-packages garminconnect curl_cffi fitparse gpxpy 2>/dev/null; then
     echo "✓ Dependencies installed (--break-system-packages)"
-elif pip3 install garminconnect fitparse gpxpy 2>/dev/null; then
+elif pip3 install garminconnect curl_cffi fitparse gpxpy 2>/dev/null; then
     echo "✓ Dependencies installed (system-wide)"
 else
     echo "❌ Failed to install Python dependencies"
-    echo "   Try manually: pip3 install --user garminconnect fitparse gpxpy"
+    echo "   Try manually: pip3 install --user garminconnect curl_cffi fitparse gpxpy"
     exit 1
 fi
 

--- a/references/mcp_setup.md
+++ b/references/mcp_setup.md
@@ -59,4 +59,4 @@ You can use both the Clawdbot skill and the MCP server simultaneously! They shar
 - **Clawdbot**: Morning health summaries, weekly reports, automated tracking
 - **Claude Desktop**: Quick ad-hoc queries during the day
 
-Authentication tokens are shared at `~/.clawdbot/garmin-tokens.json` (or `~/.garmin-tokens.json`).
+Authentication tokens are shared at `~/.clawdbot/garmin/` (garth tokenstore).

--- a/scripts/garmin_auth.py
+++ b/scripts/garmin_auth.py
@@ -1,29 +1,48 @@
 #!/usr/bin/env python3
 """
 Garmin Connect authentication helper.
-Handles login and stores session tokens.
+Handles login, token management, legacy migration, and rate-limit retry.
+
+Provides:
+  - get_client()       — return authenticated client from tokens or fresh login
+  - login(email, pw)   — explicit login, saves tokens
+  - check_status()     — verify saved tokens still work
+  - CLI: status/login  — command-line entry points
 """
 
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from datetime import datetime
 import argparse
 
 try:
-    from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError
-except ImportError:
-    print("❌ garminconnect library not installed", file=sys.stderr)
-    print("Install with: pip3 install garminconnect", file=sys.stderr)
+    from garminconnect import (
+        Garmin,
+        GarminConnectAuthenticationError,
+        GarminConnectConnectionError,
+        GarminConnectTooManyRequestsError,
+    )
+except ImportError as e:
+    print(f"❌ garminconnect library not installed ({e})", file=sys.stderr)
+    print("Install with: pip3 install garminconnect curl_cffi", file=sys.stderr)
     sys.exit(1)
 
+# ── Paths ──────────────────────────────────────────────────────────────────
 TOKEN_DIR = Path.home() / ".clawdbot" / "garmin"
+LEGACY_TOKEN_DIR = Path.home() / ".garminconnect"
 CONFIG_FILE = Path(__file__).parent.parent / "config.json"
 
+RETRY_SLEEP_SEC = 30          # seconds to wait before retrying a 429
+MAX_RETRIES = 1               # one retry after sleep seems fair
+
+
+# ── Config helpers ─────────────────────────────────────────────────────────
 
 def load_config():
-    """Load credentials from config file."""
+    """Load credentials from config.json next to this repo."""
     if not CONFIG_FILE.exists():
         return None
     try:
@@ -34,38 +53,112 @@ def load_config():
         return None
 
 
+def resolve_credentials(email=None, password=None):
+    """
+    Resolve credentials with priority:
+      1. Explicit function args
+      2. config.json file
+      3. Environment variables GARMIN_EMAIL / GARMIN_PASSWORD
+    Returns (email, password) or (None, None).
+    """
+    if email and password:
+        return email, password
+
+    config = load_config()
+    if config:
+        email = email or config.get("email")
+        password = password or config.get("password")
+
+    email = email or os.getenv("GARMIN_EMAIL")
+    password = password or os.getenv("GARMIN_PASSWORD")
+    return email, password
+
+
+# ── Token management ───────────────────────────────────────────────────────
+
+def _migrate_legacy_tokens():
+    """
+    Migrate tokens from legacy ~/.garminconnect/ to the current
+    ~/.clawdbot/garmin/ tokenstore (garth format).
+    Silent if nothing to migrate.
+    """
+    if not LEGACY_TOKEN_DIR.exists():
+        return
+    if TOKEN_DIR.exists():
+        return  # already migrated
+
+    # Check if the legacy dir has garth-dump structure (directory-based)
+    # or the old style garmin_tokens.json
+    if (LEGACY_TOKEN_DIR / "garmin_tokens.json").exists():
+        old_tokens = LEGACY_TOKEN_DIR / "garmin_tokens.json"
+        try:
+            data = json.loads(old_tokens.read_text())
+            if isinstance(data, dict) and "access_token" in data:
+                print("⚠️  Legacy garmin_tokens.json found — format too old, fresh login needed.",
+                      file=sys.stderr)
+                return
+        except Exception:
+            pass
+
+    # Try garth-dumped directory (has sub-files like cookie.json, token.json)
+    try:
+        client = Garmin()
+        client.login(str(LEGACY_TOKEN_DIR))
+        # If that works, dump to new location
+        TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        client.garth.dump(str(TOKEN_DIR))
+        TOKEN_DIR.chmod(0o700)
+        print(f"✅ Migrated tokens from {LEGACY_TOKEN_DIR} to {TOKEN_DIR}",
+              file=sys.stderr)
+    except Exception:
+        pass  # migration failed, fresh login will happen
+
+
+# ── Core auth functions ────────────────────────────────────────────────────
+
 def login(email, password):
     """Perform login and save tokens using garminconnect's tokenstore."""
+    email, password = resolve_credentials(email, password)
+    if not email or not password:
+        print("❌ Email and password required", file=sys.stderr)
+        return False
+
     try:
         print(f"🔐 Logging in as {email}...", file=sys.stderr)
-        
-        # Create token directory
+
         TOKEN_DIR.mkdir(parents=True, exist_ok=True)
         tokenstore = str(TOKEN_DIR)
-        
-        # Create client and login (don't pass tokenstore on first login)
+
         client = Garmin(email, password)
-        client.login()  # Initial login without tokenstore
-        
-        # Save tokens to tokenstore
+        client.login()
         client.garth.dump(tokenstore)
         print(f"✅ Tokens saved to {tokenstore}", file=sys.stderr)
-        
-        # Test the connection
+
+        # Verify
         try:
             profile = client.get_user_summary(datetime.now().strftime("%Y-%m-%d"))
-            print(f"✅ Login successful! User: {profile.get('displayName', 'Unknown')}", file=sys.stderr)
+            print(f"✅ Login successful! User: {profile.get('displayName', 'Unknown')}",
+                  file=sys.stderr)
         except Exception as e:
-            print(f"✅ Login successful! (Unable to fetch profile: {e})", file=sys.stderr)
-        
-        # Make tokenstore directory secure
+            print(f"✅ Login successful! (Unable to fetch profile: {e})",
+                  file=sys.stderr)
+
         TOKEN_DIR.chmod(0o700)
-        
         return True
-        
+
+    except GarminConnectTooManyRequestsError:
+        print("❌ Garmin rate-limited this IP (429).", file=sys.stderr)
+        print("   Wait ~30 minutes and retry, or use a different network/VPN.",
+              file=sys.stderr)
+        return False
     except GarminConnectAuthenticationError as e:
         print(f"❌ Authentication failed: {e}", file=sys.stderr)
-        print("Check your email/password and try again.", file=sys.stderr)
+        print("   Check your email/password and try again.", file=sys.stderr)
+        return False
+    except GarminConnectConnectionError as e:
+        print(f"❌ Connection error: {e}", file=sys.stderr)
+        print("   Check your internet connection and Garmin server status.",
+              file=sys.stderr)
         return False
     except Exception as e:
         print(f"❌ Login error: {e}", file=sys.stderr)
@@ -73,97 +166,119 @@ def login(email, password):
 
 
 def get_client():
-    """Get authenticated Garmin client, using saved tokens if available."""
+    """
+    Return an authenticated Garmin client.
+
+    Strategy:
+      1. Load saved tokens from TOKEN_DIR (with legacy migration on first call)
+      2. If tokens expired, do a fresh login using config / env credentials
+      3. On 429, retry once after RETRY_SLEEP_SEC seconds
+    Returns Garmin client or None.
+    """
+    # Migrate legacy tokens on first invocation
+    _migrate_legacy_tokens()
+
     tokenstore = str(TOKEN_DIR)
-    
-    if not TOKEN_DIR.exists():
+
+    # ── Attempt 1: saved tokens ──
+    if TOKEN_DIR.exists():
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                client = Garmin()
+                client.login(tokenstore=tokenstore)
+                client.get_user_summary(datetime.now().strftime("%Y-%m-%d"))
+                return client
+            except GarminConnectTooManyRequestsError:
+                if attempt < MAX_RETRIES:
+                    print(f"⚠️  429 rate limit — retrying in {RETRY_SLEEP_SEC}s...",
+                          file=sys.stderr)
+                    time.sleep(RETRY_SLEEP_SEC)
+                else:
+                    print("❌ Garmin rate-limited after retry (429).", file=sys.stderr)
+                    return None
+            except Exception as e:
+                # Tokens expired / invalid — fall through to fresh login
+                break  # single break, then try fresh login
+
+    # ── Attempt 2: fresh login with credentials ──
+    email, password = resolve_credentials()
+    if not email or not password:
+        print("❌ No saved tokens or credentials available.", file=sys.stderr)
+        print("   Run: python3 scripts/garmin_auth.py login", file=sys.stderr)
         return None
-    
-    try:
-        # Try to use saved tokens
-        client = Garmin()
-        client.login(tokenstore=tokenstore)
-        
-        # Test if tokens still work
-        client.get_user_summary(datetime.now().strftime("%Y-%m-%d"))
-        return client
-        
-    except Exception as e:
-        print(f"⚠️  Saved tokens expired or invalid: {e}", file=sys.stderr)
-        return None
+
+    print("ℹ️  Saved tokens expired — performing fresh login...", file=sys.stderr)
+    if login(email, password):
+        # Retry with fresh tokens
+        try:
+            client = Garmin()
+            client.login(tokenstore=tokenstore)
+            client.get_user_summary(datetime.now().strftime("%Y-%m-%d"))
+            return client
+        except Exception as e:
+            print(f"❌ Fresh login succeeded but client failed: {e}", file=sys.stderr)
+            return None
+
+    return None
 
 
 def check_status():
     """Check if we have valid authentication."""
-    tokenstore = str(TOKEN_DIR)
-    
     if not TOKEN_DIR.exists():
-        print("❌ Not authenticated", file=sys.stderr)
-        print("Run: python3 scripts/garmin_auth.py login", file=sys.stderr)
+        _migrate_legacy_tokens()
+
+    if not TOKEN_DIR.exists():
+        print("❌ Not authenticated — no token store found.", file=sys.stderr)
+        print("   Run: python3 scripts/garmin_auth.py login", file=sys.stderr)
         return False
-    
-    print(f"✅ Token store found at {tokenstore}", file=sys.stderr)
-    
-    # Test if they work
+
+    print(f"✅ Token store found at {TOKEN_DIR}", file=sys.stderr)
+
     client = get_client()
     if client:
         try:
             profile = client.get_user_summary(datetime.now().strftime("%Y-%m-%d"))
-            print(f"✅ Authentication valid! User: {profile.get('displayName', 'Unknown')}", file=sys.stderr)
+            print(f"✅ Authentication valid! User: {profile.get('displayName', 'Unknown')}",
+                  file=sys.stderr)
             return True
         except Exception as e:
-            print(f"⚠️  Tokens may be expired: {e}", file=sys.stderr)
+            print(f"⚠️  Token verification failed: {e}", file=sys.stderr)
             return False
-    
-    print("❌ Authentication invalid. Please login again.", file=sys.stderr)
+
+    print("❌ Authentication invalid.", file=sys.stderr)
     return False
 
+
+# ── CLI entry point ────────────────────────────────────────────────────────
 
 def main():
     parser = argparse.ArgumentParser(description="Garmin Connect authentication")
     subparsers = parser.add_subparsers(dest="command", help="Command")
-    
-    # Login command
+
     login_parser = subparsers.add_parser("login", help="Login to Garmin Connect")
-    login_parser.add_argument("--email", help="Garmin account email (or set via env/config)")
-    login_parser.add_argument("--password", help="Garmin account password (or set via env/config)")
-    
-    # Status command
+    login_parser.add_argument("--email", help="Garmin account email")
+    login_parser.add_argument("--password", help="Garmin account password")
+
     subparsers.add_parser("status", help="Check authentication status")
-    
+
     args = parser.parse_args()
-    
+
     if args.command == "login":
-        email = args.email
-        password = args.password
-        
-        # Priority: CLI args > config.json > environment variables
-        if not email or not password:
-            config = load_config()
-            if config:
-                email = email or config.get("email")
-                password = password or config.get("password")
-        
-        if not email or not password:
-            email = email or os.getenv("GARMIN_EMAIL")
-            password = password or os.getenv("GARMIN_PASSWORD")
-        
+        email, password = resolve_credentials(args.email, args.password)
         if not email or not password:
             print("❌ Email and password required", file=sys.stderr)
-            print("Set via:", file=sys.stderr)
-            print("  1. CLI: --email and --password", file=sys.stderr)
-            print("  2. Config: create config.json from config.example.json", file=sys.stderr)
-            print("  3. Env vars: GARMIN_EMAIL and GARMIN_PASSWORD", file=sys.stderr)
-            print("  4. Clawdbot config: skills.entries.garmin-health-analysis.env", file=sys.stderr)
+            print("   Set via:", file=sys.stderr)
+            print("   1. CLI: --email / --password", file=sys.stderr)
+            print("   2. File: config.json in repo root", file=sys.stderr)
+            print("   3. Env:  GARMIN_EMAIL / GARMIN_PASSWORD", file=sys.stderr)
             sys.exit(1)
-        
         success = login(email, password)
         sys.exit(0 if success else 1)
-    
+
     elif args.command == "status":
         success = check_status()
         sys.exit(0 if success else 1)
-    
+
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION


- Handle GarminConnectTooManyRequestsError with 30s retry in get_client()
- Token fallback: if saved tokens expire, auto-login with config/env credentials
- Legacy migration: auto-migrate tokens from ~/.garminconnect/ to ~/.clawdbot/garmin/
- Handle GarminConnectConnectionError separately
- Deduplicate credential resolution order (CLI > config > env) into resolve_credentials()
- Add curl_cffi to dependency install instructions
- Update docs: token paths, version bump to 1.2.2, migration notes

Fixes issues where:
- 429 rate limits silently failed
- Token expiration broke all subsequent calls with no recovery
- Upgrading from v1.0 lost existing token sessions